### PR TITLE
Adding helpers in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This module accepts the following options
 
 - **mockPath**: Path to mock files
 - **dataset**: Override datasets with this, accepts an object. Will only override if the sames keys are defined.
-
+- **helpers**: Your own helpers which are described in "[writing-your-own-helpers](https://github.com/webroo/dummy-json#writing-your-own-helpers)" of [dummy-json](https://github.com/webroo/dummy-json)
 
 ## Mocking
 To mock an API or a service. All you need is a folder and some files.

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function MockApiMiddleware (route, options) {
 			// Will try to parse dummyjson, if it's not sucessfull show an error
 			// This is most likely a mistake with the file, and has to be fixed.
 			try {
-				jsonData = JSON.parse(dummyjson.parse(jsonData, { mockdata: settings.dataset }));
+				jsonData = JSON.parse(dummyjson.parse(jsonData, { mockdata: settings.dataset, helpers: settings.helpers }));
 			} catch (error) {
 				showError('Could not parse Mock-JSON: ' + mockJsonPath, error);
 				return;


### PR DESCRIPTION
Hello.

 Thank you for your mock-api-middleware. It's very useful for developing web frontends including restful APIs responding with JSON.  

 I hope that the MOM can receive customized helpers which are described in the dummy-json documents "[writing-your-own-helpers](https://github.com/webroo/dummy-json#writing-your-own-helpers)" through the [options](https://www.npmjs.com/package/mock-api-middleware#options) passed on initialization of MAM.

So I sent this PR which includes adding `helpers` to the 2nd parameter object for `dummyjson.parse()`. By this, we can write the code like following:

```javascript
const mam = require('mock-api-middleware');
const myHelpers = require('./src/myHelpers');

const mockApi = mam('/api', { // <--- Route where to mount the API
    mockPath: './mock_api/', // <--- Where to find the API files
    helpers: myHelpers,
});
```
`myHelpers.js` is like following
```javascript
module.exports = {
  direction: function() {
    // Use dummyjson random to ensure the seeded random number generator is used
    return dummyjson.utils.random() > 0.5 ? 'left' : 'right';
  }
};
```
This `direction` function above enable us to write 

`{{direction}}`

in the MAM jsons and it will become a string of `left` or  `right` in API responses.

Best regards.